### PR TITLE
UPSE-297: updates for Java 11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,13 +9,16 @@ on:
 
 jobs:
   test:
-    name: '${{ matrix.platform }} with Java 8'
+    name: '${{ matrix.platform }} with Java ${{ matrix.java-version }}'
     strategy:
       matrix:
         platform:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        java-version:
+          - 8
+          - 11
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
@@ -24,6 +27,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
-          java-version: 8
+          java-version: ${{ matrix.java-version }}
       - name: Build and Test
         run: mvn -B package

--- a/pom.xml
+++ b/pom.xml
@@ -29,15 +29,17 @@
         <ehcache.version>2.6.11</ehcache.version>
         <hibernate.version>3.2.7.ga</hibernate.version>
         <hsqldb.version>1.8.0.10</hsqldb.version>
-        <javax.activation.version>1.1.1</javax.activation.version>
+	<javax.activation.version>1.1.1</javax.activation.version>
         <javax.mail>1.5.0-b01</javax.mail>
         <javax.servlet>2.5</javax.servlet>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-impl.version>2.3.3</jaxb-impl.version>
         <jstl.version>1.1.2</jstl.version>
         <jta.version>1.1</jta.version>
-        <logbackVersion>1.4.5</logbackVersion>
+        <logbackVersion>1.3.5</logbackVersion>
         <poi.version>3.17</poi.version>
         <resource-server.version>1.0.47</resource-server.version>
-        <slf4jVersion>1.7.36</slf4jVersion>
+        <slf4jVersion>2.0.6</slf4jVersion>
         <spring.version>3.2.18.RELEASE</spring.version>
         <taglib.version>1.1.2</taglib.version>
     </properties>
@@ -145,6 +147,20 @@
             <version>${jstl.version}</version>
             <type>jar</type>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>${jaxb-impl.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -366,6 +382,8 @@
                                 <bannedDependencies>
                                     <excludes>
                                         <exclude>commons-collections:commons-collections:[3.2.1]</exclude>
+                                        <exclude>commons-logging:*</exclude>
+                                        <exclude>log4j:*</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>


### PR DESCRIPTION
Updates to support Java 11:
* update github build to use Java 11 (while keeping Java 8 build for now)
* add JAXB dependencies to fix issue on first view (render fails first time, but then portlet runs fine afterwards)
* downgrade logback version to one that supports Java 8+
* add enforcement to prevent log4j and commons-logging jars from sneaking in